### PR TITLE
Fix settings save handler to avoid ReferenceError

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,7 +9,7 @@ import Operations from './components/Operations';
 import type { Page, Account, Trade, WatchlistItem } from './types';
 import { MOCK_WATCHLIST } from './constants';
 import { TradeStatus, TradeType } from './types';
-import { fetchAccounts, createAccount, fetchTrades, createTrade, closeTrade, fetchWatchlist, debugFetchProfiles } from './services/databaseService';
+import { fetchAccounts, createAccount, fetchTrades, createTrade, closeTradeInDb, fetchWatchlist, debugFetchProfiles } from './services/databaseService';
 
 
 const App: React.FC = () => {

--- a/components/Accounts.tsx
+++ b/components/Accounts.tsx
@@ -149,7 +149,11 @@ const Accounts: React.FC<AccountsProps> = ({ accounts, addAccount }) => {
       setIsSaving(true);
       setSaveMessage(null);
       setSettingsError(null);
-      
+
+      const newSettings: UserProfile = {
+        ...settings
+      };
+
       await updateUserProfile(newSettings);
       setOriginalSettings(newSettings);
       setSaveMessage({ type: 'success', text: 'Profile updated successfully' });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     ],
     "skipLibCheck": true,
     "types": [
-      "node"
+      "node",
+      "vite/client"
     ],
     "moduleResolution": "bundler",
     "isolatedModules": true,


### PR DESCRIPTION
## Summary
- clone the current account settings before saving to avoid ReferenceError and persist the snapshot in state
- import the correct database helper for closing trades and include Vite types so TypeScript recognizes `import.meta.env`

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68d065aa45d88322be4ee06c39862a7d